### PR TITLE
Implement a security group check for non DEV env.

### DIFF
--- a/MXppTools/MXppTools/AxForm/MXTInterpreterParameters.xml
+++ b/MXppTools/MXppTools/AxForm/MXTInterpreterParameters.xml
@@ -39,6 +39,9 @@ public class MXTInterpreterParameters extends FormRun
 			<Table>MXTXppInterpreterParameters</Table>
 			<Fields>
 				<AxFormDataSourceField>
+					<DataField>DoNotLogOnDevEnv</DataField>
+				</AxFormDataSourceField>
+				<AxFormDataSourceField>
 					<DataField>EmitGlobalTtsAbort</DataField>
 				</AxFormDataSourceField>
 				<AxFormDataSourceField>
@@ -179,6 +182,15 @@ public class MXTInterpreterParameters extends FormRun
 										<FormControlExtension
 											i:nil="true" />
 										<DataField>EmitGlobalTtsAbort</DataField>
+										<DataSource>MXTXppInterpreterParameters</DataSource>
+									</AxFormControl>
+									<AxFormControl xmlns=""
+										i:type="AxFormCheckBoxControl">
+										<Name>MXTXppInterpreterParameters_DoNotLogOnDevEnv</Name>
+										<Type>CheckBox</Type>
+										<FormControlExtension
+											i:nil="true" />
+										<DataField>DoNotLogOnDevEnv</DataField>
 										<DataSource>MXTXppInterpreterParameters</DataSource>
 									</AxFormControl>
 								</Controls>

--- a/MXppTools/MXppTools/AxSecurityRole/MXTXppInterpreterRole.xml
+++ b/MXppTools/MXppTools/AxSecurityRole/MXTXppInterpreterRole.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<AxSecurityRole xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+	<Name>MXTXppInterpreterRole</Name>
+	<Description>Users in this role can run MXT X++ Interpreter</Description>
+	<Label>MXT X++ Interpreter</Label>
+	<DirectAccessPermissions />
+	<Duties />
+	<Privileges />
+	<SubRoles />
+</AxSecurityRole>

--- a/MXppTools/MXppTools/AxTable/MXTXppInterpreterParameters.xml
+++ b/MXppTools/MXppTools/AxTable/MXTXppInterpreterParameters.xml
@@ -109,6 +109,14 @@ public class MXTXppInterpreterParameters extends common
 			<Name>MaxLoopIteratations</Name>
 			<Label>@MXT:MaxLoopIterations</Label>
 		</AxTableField>
+		<AxTableField xmlns=""
+			i:type="AxTableFieldEnum">
+			<Name>DoNotLogOnDevEnv</Name>
+			<ExtendedDataType>NoYesId</ExtendedDataType>
+			<HelpText>Skip loggging on Dev env.</HelpText>
+			<Label>Skip log on Dev env.</Label>
+			<EnumType>NoYes</EnumType>
+		</AxTableField>
 	</Fields>
 	<FullTextIndexes />
 	<Indexes>

--- a/MXppTools/MXppTools/AxTable/MXTXppInterpreterScriptExecutionLog.xml
+++ b/MXppTools/MXppTools/AxTable/MXTXppInterpreterScriptExecutionLog.xml
@@ -45,18 +45,78 @@ public class MXTXppInterpreterScriptExecutionLog extends common
 ]]></Source>
 			</Method>
 			<Method>
+				<Name>isUserInRole</Name>
+				<Source><![CDATA[
+    public static boolean isUserInRole(Description  _roleName)
+    {
+        boolean                 res;
+        SecurityUserRole        securityUserRole;
+        SecurityRole            securityRole;
+        ;
+        select firstonly RecId from securityUserRole
+            where  securityUserRole.User    == curUserId()
+            join RecId from securityRole
+                where  securityRole.RecId == securityUserRole.SecurityRole
+                    && (   securityRole.AotName == _roleName
+                    )    ;
+        if (securityUserRole.RecId)
+        {
+            res = true;
+        }
+        return res;
+    }
+
+]]></Source>
+			</Method>
+			<Method>
+				<Name>checkSecurityRights</Name>
+				<Source><![CDATA[
+    public static boolean checkSecurityRights()
+    {
+        boolean res;
+        if (isSystemAdministrator()) 
+        {   
+            //we are on the dev version, do not check the group
+            if (isDeveloper())
+            {
+                res = true;
+            }
+            else
+            {
+                if (! MXTXppInterpreterScriptExecutionLog::isUserInRole(roleStr(MXTXppInterpreterRole)) )
+                {
+                    throw error(strFmt("User %1 should be included to %2 role",
+                        curUserId(), roleStr(MXTXppInterpreterRole)));
+                }
+            }
+        }
+        else
+        {
+            throw error("Only System Administrator can run this tool");
+        }
+
+        return res;
+    }
+
+]]></Source>
+			</Method>
+			<Method>
 				<Name>startLog</Name>
 				<Source><![CDATA[
     public static MXTXppInterpreterScriptExecutionLog startLog(str _sourceCode, boolean  _emitGlobalTtsAbort)
     {
         MXTXppInterpreterScriptExecutionLog         scriptExecutionLog;
 
-        scriptExecutionLog = null;
-        scriptExecutionLog.initValue();
-        scriptExecutionLog.SourceCode         = _sourceCode;
-        scriptExecutionLog.EmitGlobalTtsAbort = _emitGlobalTtsAbort;
-        scriptExecutionLog.insert();
+        MXTXppInterpreterScriptExecutionLog::checkSecurityRights();
 
+        if (! (isSystemAdministrator() && isDeveloper() && MXTXppInterpreterParameters::find().DoNotLogOnDevEnv))
+        {
+            scriptExecutionLog = null;
+            scriptExecutionLog.initValue();
+            scriptExecutionLog.SourceCode         = _sourceCode;
+            scriptExecutionLog.EmitGlobalTtsAbort = _emitGlobalTtsAbort;
+            scriptExecutionLog.insert();
+        }
         return scriptExecutionLog;
     }
 


### PR DESCRIPTION
this is to cover #4 
Added the following logic

- Created a group MXTXppInterpreterRole
- Implemented a validation that for a non DEV evn. (the check is the same as the condition in SysTableBrowser-new) user should be a sysadmin PLUS be included in the MXTXppInterpreterRole

This will give some logical protection for projects that will not allow sysadmins to use this tool. So in order to use it on TIER2 you need to be SysAdmin + has a special group allocated to you

also added a parameter to disable logging on DEV env. For example you learn something, you don't want override your DB with long scripts