### PR TITLE
MXTScriptEditor open specific script providing ScriptId parm in url

### DIFF
--- a/Metadata/MXppTools/MXppTools/AxForm/MXTScriptEditor.xml
+++ b/Metadata/MXppTools/MXppTools/AxForm/MXTScriptEditor.xml
@@ -271,6 +271,13 @@ public class MXTScriptEditor extends FormRun
                 callerScript = MXTXppInterpreterScript::find(dependency.ReferenceScriptId);
                 break;
         }
+        if (!callerScript) // If form is called directly from url, check if ScriptId is provided
+        {
+            URLUtility  urlUtility  = new URLUtility();
+            str         scriptId    = urlUtility.getQueryParamValue(identifierStr(ScriptId));
+
+            callerScript = MXTXppInterpreterScript::find(str2Int64(scriptId));
+        }					
 
         super();
     }


### PR DESCRIPTION
Add possibility to open explicit script from url. Example d365fo_url/&mi=MXTScriptEditor&ScriptId=5637162576